### PR TITLE
url as argument ,time fix and proper naming for message sent

### DIFF
--- a/conf/skype_conf.py
+++ b/conf/skype_conf.py
@@ -4,4 +4,4 @@ Skype conf
 import time
 
 SKYPE_SENDER_ENDPOINT = "https://skype-sender.qxf2.com/send-message"
-MESSAGE = 'This is a test message - ' + ''.join(time.time().__str__().split('.'))
+MESSAGE = 'This is a test message - ' + ''.join(time.ctime().__str__().split('.'))

--- a/conf/skype_conf.py
+++ b/conf/skype_conf.py
@@ -1,7 +1,7 @@
 """
 Skype conf
 """
-import random
+import time
 
 SKYPE_SENDER_ENDPOINT = "https://skype-sender.qxf2.com/send-message"
-MESSAGE = 'This is a test message - ' + ''.join(random.choices(['s', 'h', 'i', 'v', 'a']))
+MESSAGE = 'This is a test message - ' + ''.join(time.time().__str__().split('.'))

--- a/helpers/skype_helper.py
+++ b/helpers/skype_helper.py
@@ -15,7 +15,7 @@ class SkypeHelper(BaseHelper):
     Skype Helper object
     """
 
-    def post_message_on_skype(self, message):
+    def post_message_on_skype(self, message, url):
         "Posts a predefined message on the set Skype channel"
         try:
             headers = {'Content-Type': 'application/json'}
@@ -23,7 +23,7 @@ class SkypeHelper(BaseHelper):
                       "channel": os.environ['CHANNEL_ID'],
                       "API_KEY": os.environ['API_KEY']}
 
-            response = requests.post(url=skype_conf.SKYPE_SENDER_ENDPOINT,
+            response = requests.post(url=url,
                                      json=payload, headers=headers)
             if response.status_code == 200:
                 self.write(f'Successfully sent the Skype message - {message}')

--- a/tests/test_message_sqs.py
+++ b/tests/test_message_sqs.py
@@ -3,8 +3,7 @@
   - Validate message sent to Skype channel against the message received on SQS
 """
 import time
-from conf import sqs_conf
-from conf import skype_conf
+from conf import sqs_conf, skype_conf
 
 def test_message_received_sqs(sqs_instance, skype_instance, concurrent_obj):
     """
@@ -14,15 +13,16 @@ def test_message_received_sqs(sqs_instance, skype_instance, concurrent_obj):
         with concurrent_obj.ThreadPoolExecutor() as executor:
             future = executor.submit(sqs_instance.get_message_from_queue, sqs_conf.SQS_NAME)
             # wait 3 secs before triggering Skype message
-            message = skype_conf.MESSAGE
+            message_sent = skype_conf.MESSAGE
+            url = skype_conf.SKYPE_SENDER_ENDPOINT
             time.sleep(3)
-            trigger_skype_message = skype_instance.post_message_on_skype(message)
+            trigger_skype_message = skype_instance.post_message_on_skype(message_sent, url)
             sqs_messages = future.result()
 
         # validate if message found
         if_message_found = False
         for msg in sqs_messages:
-            if message in msg:
+            if message_sent in msg:
                 if_message_found = True
                 break
         assert if_message_found


### PR DESCRIPTION
I've added following fixes in this PR-
1. Message are sent using with timestamp.
2. URL is taken as argument for post_mesage_on_skype method.

To run the test:
 python -m pytest tests/test_message_sqs.py -sv